### PR TITLE
Hotfix/passcode keyboard not displaying

### DIFF
--- a/ResearchKit/Common/ORKPasscodeStepViewController.m
+++ b/ResearchKit/Common/ORKPasscodeStepViewController.m
@@ -377,7 +377,8 @@ static CGFloat const kForgotPasscodeHeight              = 100.0f;
                                                             }]];
                     [strongSelf presentViewController:alert animated:YES completion:nil];
                 } else if (error.code == LAErrorUserCancel) {
-                    [strongSelf makePasscodeViewBecomeFirstResponder];
+                    //fixes issue that prevents keyboard from appearing on iphone SE
+                    [strongSelf performSelector:@selector(makePasscodeViewBecomeFirstResponder) withObject:self afterDelay:1];
                 }
                 
                 [strongSelf finishTouchId];


### PR DESCRIPTION
Added code to fix display bug on the passcode keyboard for iPhone SE. This fix was implemented on previous RK 1.3 versions.