### PR TITLE
Update ORKQuestionStep to support 'preventImmediateNavigation' property

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -160,7 +160,7 @@
 		866DA5291D63D04700C9AF3F /* ORKOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 866DA51D1D63D04700C9AF3F /* ORKOperation.h */; };
 		866DA52A1D63D04700C9AF3F /* ORKOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 866DA51E1D63D04700C9AF3F /* ORKOperation.m */; };
 		866F86011A96CBF3007B282C /* ORKSurveyAnswerCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 866F86001A96CBF3007B282C /* ORKSurveyAnswerCell.m */; };
-		86AD910A1AB7AD1E00361FEB /* ORKNavigationContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AD91081AB7AD1E00361FEB /* ORKNavigationContainerView.h */; };
+		86AD910A1AB7AD1E00361FEB /* ORKNavigationContainerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AD91081AB7AD1E00361FEB /* ORKNavigationContainerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		86AD910B1AB7AD1E00361FEB /* ORKNavigationContainerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 86AD91091AB7AD1E00361FEB /* ORKNavigationContainerView.m */; };
 		86AD910D1AB7AE4100361FEB /* ORKNavigationContainerView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AD910C1AB7AE4100361FEB /* ORKNavigationContainerView_Internal.h */; };
 		86AD91101AB7B8A600361FEB /* ORKActiveStepView.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AD910E1AB7B8A600361FEB /* ORKActiveStepView.h */; };
@@ -1436,6 +1436,7 @@
 				86CC8EA61AC09383001CCD89 /* ResearchKitTests */,
 				3FFF183F1829DB1D00167070 /* Frameworks */,
 				3FFF183E1829DB1D00167070 /* Products */,
+				5425CA28204E220C0073C94D /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1454,6 +1455,14 @@
 				B1C7955D1A9FBF04007279BA /* HealthKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		5425CA28204E220C0073C94D /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				FB30E8571C7D030F0005AD25 /* ORKTextButton_Internal.h */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		618DA0471A93D0D600E63AA8 /* Accessibility */ = {
@@ -2646,7 +2655,6 @@
 				147503B91AEE807C004B17F3 /* ORKToneAudiometryStep.h in Headers */,
 				106FF2A21B665B86004EACF2 /* ORKHolePegTestPlaceStepViewController.h in Headers */,
 				24A4DA101B8D0F21009C797A /* ORKPasscodeStepView.h in Headers */,
-				86C40C9A1A8D7C5C00081FAC /* ORKDataLogger_Private.h in Headers */,
 				2489F7B11D65214D008DEF20 /* ORKVideoCaptureStep.h in Headers */,
 				861D11AD1AA7951F003C98A7 /* ORKChoiceAnswerFormatHelper.h in Headers */,
 				86C40C461A8D7C5C00081FAC /* ORKSpatialSpanMemoryStepViewController.h in Headers */,

--- a/ResearchKit/Common/ORKNavigationContainerView.h
+++ b/ResearchKit/Common/ORKNavigationContainerView.h
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL neverHasContinueButton;
 
 @property (nonatomic, assign) BOOL skipEnabled;
+@property (nonatomic, assign) BOOL hideSkipButton;
 
 @property (nonatomic, assign) CGFloat topMargin;
 @property (nonatomic, assign) CGFloat bottomMargin;

--- a/ResearchKit/Common/ORKNavigationContainerView.h
+++ b/ResearchKit/Common/ORKNavigationContainerView.h
@@ -30,10 +30,11 @@
 
 
 @import UIKit;
-
+#import <ResearchKit/ORKDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+ORK_CLASS_AVAILABLE
 @interface ORKNavigationContainerView : UIView
 
 @property (nonatomic, strong, nullable) UIBarButtonItem *skipButtonItem;

--- a/ResearchKit/Common/ORKNavigationContainerView.m
+++ b/ResearchKit/Common/ORKNavigationContainerView.m
@@ -133,7 +133,7 @@
 }
 
 - (BOOL)skipButtonHidden {
-    return (!_skipButtonItem) || _useNextForSkip || !self.optional;
+    return (!_skipButtonItem) || _useNextForSkip || !self.optional || self.hideSkipButton;
 }
 
 - (CGFloat)skipButtonAlpha {

--- a/ResearchKit/Common/ORKQuestionStep.h
+++ b/ResearchKit/Common/ORKQuestionStep.h
@@ -106,6 +106,15 @@ ORK_CLASS_AVAILABLE
   */
 @property (nonatomic, copy, nullable) NSString *placeholder;
 
+/**
+ Custom property. -jmkr 3/5/18
+ We wanted to be able to let a user 'confirm' their answer when making a selection on required fields. This
+ lets us prevent immediate navigation to the next question when an answer is selected, and also hides the skip
+ button for non-optional question types.
+
+ */
+@property (nonatomic, assign) BOOL preventImmediateNavigation;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKQuestionStep.m
+++ b/ResearchKit/Common/ORKQuestionStep.m
@@ -149,7 +149,7 @@
 
 - (BOOL)isFormatImmediateNavigation {
     ORKQuestionType questionType = self.questionType;
-    return (self.optional == NO) && ((questionType == ORKQuestionTypeBoolean) || (questionType == ORKQuestionTypeSingleChoice));
+    return (self.optional == NO) && (self.preventImmediateNavigation == NO) && ((questionType == ORKQuestionTypeBoolean) || (questionType == ORKQuestionTypeSingleChoice));
 }
 
 - (BOOL)isFormatChoiceWithImageOptions {


### PR DESCRIPTION
* We wanted to provide a way for users to review answers and be prompted with a Next button on certain non-optional question types, including: `select`, `radio`, `multi-yes-no`, `multi-true-false`.
* This prevents the default behavior of immediately pushing to the next screen when a user makes a selection for those question types listed above, or any currently using the ResearchKit answer format `ORKChoiceAnswerStyleSingleChoice`. 